### PR TITLE
Improve unpacking

### DIFF
--- a/run_once.sh
+++ b/run_once.sh
@@ -6,10 +6,7 @@ echo "Importing Pre Dumps into /tmp"
 git clone https://github.com/nZEDb/nZEDbPre_Dumps.git
 
 echo "Uncompressing GZIPs"
-for dir in /tmp/nZEDbPre_Dumps/dumps/*; do
-        [ -e "$dir" ] || continue
-        cd $dir && gunzip ./*
-done
+find /tmp/nZEDbPre_Dumps/dumps/ -name "*.csv.gz" -exec gunzip "{}" \;
 
 cd /tmp
 


### PR DESCRIPTION
The original script fails on a file. I think we can also drop the complete loop.


Uncompressing GZIPs
./dumps.sh: line 11: cd: /tmp/nZEDbPre_Dumps/dumps/0README.txt: Not a directory Generating Import Script
Importing